### PR TITLE
[Fix] gradle.build 에러 수정

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'ddogdog'
+rootProject.name = 'DDogdog'


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#2 
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- java.lang.IllegalStateException 에러로 gradle build가 진행되지않았었다.
- 실제 프로젝트명과 setting.gradle의 rootProject.name을 일치시켜 에러를 해결하였다.

### 스크린샷 (선택)

