### PR TITLE
[Feature] S3 설정 및 이미지 업로드,삭제 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	//gson 설정
 	implementation 'com.google.code.gson:gson:2.8.9'
+	// s3를 위한 cloud
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sysone/ddogdog/common/config/S3Config.java
+++ b/src/main/java/com/sysone/ddogdog/common/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.sysone.ddogdog.common.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/sysone/ddogdog/common/config/s3/Exception/ErrorCode.java
+++ b/src/main/java/com/sysone/ddogdog/common/config/s3/Exception/ErrorCode.java
@@ -1,0 +1,26 @@
+package com.sysone.ddogdog.common.config.s3.Exception;
+
+public enum ErrorCode {
+    EMPTY_FILE_EXCEPTION("파일이 존재하지 않습니다", 400),
+    NO_FILE_EXTENTION("파일이 확장자명이 존재하지않습니다", 400),
+    INVALID_FILE_EXTENTION("올바르지않은 확장자명입니다", 400),
+    IO_EXCEPTION_ON_IMAGE_UPLOAD("IO exception occurred during image upload", 500),
+    PUT_OBJECT_EXCEPTION("Error occurred while uploading image to S3", 500),
+    IO_EXCEPTION_ON_IMAGE_DELETE("IO exception occurred during image deletion", 500);
+
+    private final String message;
+    private final int status;
+
+    ErrorCode(String message, int status) {
+        this.message = message;
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/sysone/ddogdog/common/config/s3/Exception/S3Exception.java
+++ b/src/main/java/com/sysone/ddogdog/common/config/s3/Exception/S3Exception.java
@@ -1,0 +1,20 @@
+package com.sysone.ddogdog.common.config.s3.Exception;
+
+public class S3Exception extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public S3Exception(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public S3Exception(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/sysone/ddogdog/common/config/s3/controller/S3ImageController.java
+++ b/src/main/java/com/sysone/ddogdog/common/config/s3/controller/S3ImageController.java
@@ -1,0 +1,29 @@
+package com.sysone.ddogdog.common.config.s3.controller;
+
+import com.sysone.ddogdog.common.config.s3.service.S3ImageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class S3ImageController {
+
+    private final S3ImageService s3ImageService;
+
+    @PostMapping("/s3/upload")
+    public ResponseEntity<?> s3Upload(@RequestPart(value = "image", required = false) MultipartFile image){
+        log.info("업로드 진입");
+        String profileImage = s3ImageService.upload(image);
+        return ResponseEntity.ok(profileImage);
+    }
+
+    @GetMapping("/s3/delete")
+    public ResponseEntity<?> s3delete(@RequestParam String addr){
+        s3ImageService.deleteImageFromS3(addr);
+        return ResponseEntity.ok(null);
+    }
+}

--- a/src/main/java/com/sysone/ddogdog/common/config/s3/controller/S3ImageViewController.java
+++ b/src/main/java/com/sysone/ddogdog/common/config/s3/controller/S3ImageViewController.java
@@ -1,0 +1,13 @@
+package com.sysone.ddogdog.common.config.s3.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class S3ImageViewController {
+
+    @GetMapping("/s3/test")
+    public String s3Test(){
+        return "common/s3/testPage";
+    }
+}

--- a/src/main/java/com/sysone/ddogdog/common/config/s3/service/S3ImageService.java
+++ b/src/main/java/com/sysone/ddogdog/common/config/s3/service/S3ImageService.java
@@ -1,0 +1,161 @@
+package com.sysone.ddogdog.common.config.s3.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import com.sysone.ddogdog.common.config.s3.Exception.ErrorCode;
+import com.sysone.ddogdog.common.config.s3.Exception.S3Exception;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class S3ImageService {
+
+    private final AmazonS3Client amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    /**
+     * [ S3에 저장된 객체의 url을 반환하는 메서드 ]
+     *
+     * @param image
+     * @return String image url
+     */
+    public String upload(MultipartFile image) {
+        log.info("upload진입");
+        if (image.isEmpty() || Objects.isNull(image.getOriginalFilename())) {
+            throw new S3Exception(ErrorCode.EMPTY_FILE_EXCEPTION);
+        }
+        return this.uploadImage(image);
+    }
+
+    /**
+     * [ 호출함수 - 1. 확장자명 검증 메서드 호출 2. 이미지 업로드 메서드로 반환 ]
+     *
+     * @param image
+     * @return uploadImageToS3 호출
+     * @throws S3Exception 이미지 업로드 실패
+     */
+    private String uploadImage(MultipartFile image) {
+        log.info("사전 검사");
+        this.validateImageFileExtention(image.getOriginalFilename());
+        try {
+            return this.uploadImageToS3(image);
+        } catch (IOException e) {
+            throw new S3Exception(ErrorCode.IO_EXCEPTION_ON_IMAGE_UPLOAD);
+        }
+    }
+
+    /**
+     * [ 파일 확장자 검증 api ]
+     *
+     * @param filename - image.getOriginalFilename()
+     * @throws S3Exception 일치하는 확장자가 없습니다
+     */
+    private void validateImageFileExtention(String filename) {
+        log.info("확장자 검사");
+        int lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            throw new S3Exception(ErrorCode.NO_FILE_EXTENTION);
+        }
+
+        String extention = filename.substring(lastDotIndex + 1).toLowerCase();
+        List<String> allowedExtentionList = Arrays.asList("jpg", "jpeg", "png", "gif");
+
+        if (!allowedExtentionList.contains(extention)) {
+            throw new S3Exception(ErrorCode.INVALID_FILE_EXTENTION);
+        }
+    }
+
+    /**
+     * [ S3에 이미지 업로드하는 api ]
+     *
+     * @param image - 업로드하는 이미지
+     * @return url - 업로드완료된 버켓과 이미지 url 반환
+     * @throws S3Exception S3에 업로드하던 도중 오류가 발생했습니다
+     */
+    private String uploadImageToS3(MultipartFile image) throws IOException {
+        log.info("upload이미지진입");
+        String originalFilename = image.getOriginalFilename();
+        String extention = originalFilename.substring(originalFilename.lastIndexOf("."));
+        log.info("파일 확장자: {}", extention);
+        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename;
+
+        InputStream is = image.getInputStream();
+        byte[] bytes = IOUtils.toByteArray(is);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("image/" + extention);
+        metadata.setContentLength(bytes.length);
+
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+        try {
+            PutObjectRequest putObjectRequest =
+                    new PutObjectRequest(bucketName, s3FileName, byteArrayInputStream, metadata);
+            log.info(putObjectRequest.toString());
+            amazonS3.putObject(putObjectRequest);
+            log.info("파일 업로드 성공: {}", s3FileName);
+        } catch (Exception e) {
+            log.error("S3 업로드 실패", e);
+            throw new S3Exception(ErrorCode.PUT_OBJECT_EXCEPTION);
+        } finally {
+            byteArrayInputStream.close();
+            is.close();
+        }
+
+        return amazonS3.getUrl(bucketName, s3FileName).toString();
+    }
+
+    /**
+     * [ 이미지 제거 api ]
+     *
+     * @param imageAddress - 이미지 url 받아 getKeyFromImageAddress()를 호출하여 삭제에 필요한 key 얻음
+     * @throws S3Exception 이미지 삭제하던 중 오류발생
+     */
+    public void deleteImageFromS3(String imageAddress) {
+        String key = getKeyFromImageAddress(imageAddress);
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+        } catch (Exception e) {
+            throw new S3Exception(ErrorCode.IO_EXCEPTION_ON_IMAGE_DELETE);
+        }
+    }
+
+    /**
+     * [ 이미지 제거 api ]
+     *
+     * @param imageAddress - 이미지 url 받아 key 분리
+     * @return decodingKey
+     * @throws S3Exception 이미지 삭제하던 중 오류발생
+     */
+    private String getKeyFromImageAddress(String imageAddress) {
+        try {
+            URL url = new URL(imageAddress);
+            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            return decodingKey.substring(1); // 맨 앞의 '/' 제거
+        } catch (MalformedURLException | UnsupportedEncodingException e) {
+            throw new S3Exception(ErrorCode.IO_EXCEPTION_ON_IMAGE_DELETE);
+        }
+    }
+}

--- a/src/main/java/com/sysone/ddogdog/common/config/s3/service/S3ImageService.java
+++ b/src/main/java/com/sysone/ddogdog/common/config/s3/service/S3ImageService.java
@@ -67,7 +67,7 @@ public class S3ImageService {
     }
 
     /**
-     * [ 파일 확장자 검증 api ]
+     * [ 파일 확장자 검증 메서드 ]
      *
      * @param filename - image.getOriginalFilename()
      * @throws S3Exception 일치하는 확장자가 없습니다
@@ -88,7 +88,7 @@ public class S3ImageService {
     }
 
     /**
-     * [ S3에 이미지 업로드하는 api ]
+     * [ S3에 이미지 업로드하는 메서드 ]
      *
      * @param image - 업로드하는 이미지
      * @return url - 업로드완료된 버켓과 이미지 url 반환
@@ -128,7 +128,7 @@ public class S3ImageService {
     }
 
     /**
-     * [ 이미지 제거 api ]
+     * [ 이미지 제거 메서드 ]
      *
      * @param imageAddress - 이미지 url 받아 getKeyFromImageAddress()를 호출하여 삭제에 필요한 key 얻음
      * @throws S3Exception 이미지 삭제하던 중 오류발생
@@ -143,7 +143,7 @@ public class S3ImageService {
     }
 
     /**
-     * [ 이미지 제거 api ]
+     * [ url에서 key값 받아오는 메서드 ]
      *
      * @param imageAddress - 이미지 url 받아 key 분리
      * @return decodingKey

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,11 @@ spring:
     view:
       prefix: /WEB-INF/views/
       suffix: .jsp
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 server:
   servlet:

--- a/src/main/resources/static/js/common/s3/testPage.js
+++ b/src/main/resources/static/js/common/s3/testPage.js
@@ -1,0 +1,21 @@
+document.getElementById("uploadForm").onsubmit = function (event) {
+    event.preventDefault();  // 기본 폼 제출 방지
+
+    let formData = new FormData();
+    let fileInput = document.getElementById("image");
+    formData.append("image", fileInput.files[0]);
+
+    axios.post('/s3/upload', formData, {
+        headers: {
+            'Content-Type': 'multipart/form-data'
+        }
+    })
+        .then(response => {
+            alert("File uploaded successfully: " + response.data);
+            console.log(response.data)
+        })
+        .catch(error => {
+            alert("Failed to upload the file.");
+            console.error("Error:", error);
+        });
+};

--- a/src/main/webapp/WEB-INF/views/common/s3/testPage.jsp
+++ b/src/main/webapp/WEB-INF/views/common/s3/testPage.jsp
@@ -12,29 +12,6 @@
     <input type="file" id="image" name="image" required />
     <button type="submit">Upload</button>
 </form>
-
-<script>
-    document.getElementById("uploadForm").onsubmit = function(event) {
-        event.preventDefault();  // 기본 폼 제출 방지
-
-        let formData = new FormData();
-        let fileInput = document.getElementById("image");
-        formData.append("image", fileInput.files[0]);
-
-        axios.post('/s3/upload', formData, {
-            headers: {
-                'Content-Type': 'multipart/form-data'
-            }
-        })
-            .then(response => {
-                alert("File uploaded successfully: " + response.data);
-                console.log(response.data)
-            })
-            .catch(error => {
-                alert("Failed to upload the file.");
-                console.error("Error:", error);
-            });
-    };
-</script>
+<script src="/js/common/s3/testPage.js"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/common/s3/testPage.jsp
+++ b/src/main/webapp/WEB-INF/views/common/s3/testPage.jsp
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>File Upload</title>
+    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+</head>
+<body>
+<form id="uploadForm">
+    <label for="image">Upload Image:</label>
+    <input type="file" id="image" name="image" required />
+    <button type="submit">Upload</button>
+</form>
+
+<script>
+    document.getElementById("uploadForm").onsubmit = function(event) {
+        event.preventDefault();  // 기본 폼 제출 방지
+
+        let formData = new FormData();
+        let fileInput = document.getElementById("image");
+        formData.append("image", fileInput.files[0]);
+
+        axios.post('/s3/upload', formData, {
+            headers: {
+                'Content-Type': 'multipart/form-data'
+            }
+        })
+            .then(response => {
+                alert("File uploaded successfully: " + response.data);
+                console.log(response.data)
+            })
+            .catch(error => {
+                alert("Failed to upload the file.");
+                console.error("Error:", error);
+            });
+    };
+</script>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #22 
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] S3 설정을 위한 cloud 의존성 추가
- [x] 이미지 업로드 크기 제한을 위한 yml 세팅
- [x] 이미지 업로드 api 구현
- [x] 이미지 삭제 api 구현
 
### 스크린샷 (선택)
1. 파일 선택을 눌러 원하는 파일을 업로드 가능합니다. 
![image](https://github.com/user-attachments/assets/ef404ab3-a238-4cdd-8970-7ffaf55d3119)
2. 업로드 이후에는 해당 업로드 된 주소가 반환됩니다. // TODO : 사진 사용 시 해당 주소 DB 저장 로직 추가
3. 해당 반환 주소로 삭제 요청을 보내면 정상적으로 삭제됩니다.
![image](https://github.com/user-attachments/assets/75b62aa4-2a71-46fb-a00a-361c86bccd54)
- 저장
![image](https://github.com/user-attachments/assets/26d381db-151c-417b-b5d4-49c61e8cfc31)
- 삭제
![image](https://github.com/user-attachments/assets/1fae2e04-0a46-47e2-8056-da30f07ebc48)



## 💬리뷰 요구사항(선택)
- 메서드를 이해하기 쉽게 javadoc로 주석을 달아서 해당 메서드에 마우스를 가져다대면 정보를 바로바로 확인가능합니다. (불필요한 주석이 많아져 장단점이있습니다. 어떻게 생각하시나요)
- 로그를 이곳저곳 많이 찍어뒀는데 이미지 업로드 DB연동 이후 삭제하는 작업을 수행하겠습니다!
![image](https://github.com/user-attachments/assets/eb47e7d4-5299-410f-bfe8-ae5df6079b2a)

