### PR TITLE
[Feature] 월별 일별 예약 조회 API 생성

### DIFF
--- a/src/main/java/com/sysone/ddogdog/owner/auth/controller/AuthController.java
+++ b/src/main/java/com/sysone/ddogdog/owner/auth/controller/AuthController.java
@@ -4,24 +4,19 @@ import com.sysone.ddogdog.owner.auth.model.AuthDTO;
 import com.sysone.ddogdog.owner.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/owners")
 public class AuthController {
 
     private final AuthService authService;
-
-    @GetMapping("/signup")
-    public String signUpForm() {
-        return "owner/signUp";
-    }
 
     @GetMapping("/{id}")
     public ResponseEntity<Boolean> findId(@PathVariable String id) {
@@ -34,8 +29,4 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/login")
-    public String loginForm() {
-        return "owner/login";
-    }
 }

--- a/src/main/java/com/sysone/ddogdog/owner/auth/controller/AuthViewController.java
+++ b/src/main/java/com/sysone/ddogdog/owner/auth/controller/AuthViewController.java
@@ -1,0 +1,23 @@
+package com.sysone.ddogdog.owner.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/v1/owners")
+@RequiredArgsConstructor
+public class AuthViewController {
+
+    @GetMapping("/signup")
+    public String signUpForm() {
+        return "owner/signUp";
+    }
+
+    @GetMapping("/login")
+    public String loginForm() {
+        return "owner/login";
+    }
+
+}

--- a/src/main/java/com/sysone/ddogdog/owner/hotel/controller/HotelController.java
+++ b/src/main/java/com/sysone/ddogdog/owner/hotel/controller/HotelController.java
@@ -2,52 +2,27 @@ package com.sysone.ddogdog.owner.hotel.controller;
 
 import com.sysone.ddogdog.common.config.form.CustomDetails;
 import com.sysone.ddogdog.owner.hotel.model.RequestHotelDTO;
-import com.sysone.ddogdog.owner.hotel.model.ResponseHotelDTO;
 import com.sysone.ddogdog.owner.hotel.service.OwnerHotelService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller("ownerHotelController") //customer의 hotellcontroller와  명칭 중복으로 빈등록 이름 지정
+@RestController("ownerHotelController") //customer의 hotellcontroller와  명칭 중복으로 빈등록 이름 지정
 @RequiredArgsConstructor
 @RequestMapping("/v1/owners/hotels")
 public class HotelController {
 
     private final OwnerHotelService hotelService;
 
-    @GetMapping("/form")
-    public String getHotelForm() {
-        return "owner/hotelRegister";
-    }
-
     @PostMapping
     public ResponseEntity<Void> saveHotel(@AuthenticationPrincipal CustomDetails user, @ModelAttribute RequestHotelDTO requestHotelDTO) {
         hotelService.saveHotel(user.getUsername(), requestHotelDTO);
         return ResponseEntity.ok().build();
-    }
-
-    @GetMapping
-    public String getHotelList(@AuthenticationPrincipal CustomDetails user, Model model) {
-
-        List<ResponseHotelDTO> hotels = hotelService.getHotelsByUserId(user.getUsername());
-        model.addAttribute("hotels", hotels);
-        return "owner/hotelList";
-    }
-
-    @GetMapping("/{id}")
-    public String getHotel(@PathVariable Integer id, Model model) {
-        ResponseHotelDTO hotel = hotelService.getHotel(id);
-        model.addAttribute("hotel", hotel);
-        return "owner/updateHotel";
     }
 
     @PutMapping

--- a/src/main/java/com/sysone/ddogdog/owner/hotel/controller/HotelViewController.java
+++ b/src/main/java/com/sysone/ddogdog/owner/hotel/controller/HotelViewController.java
@@ -1,0 +1,42 @@
+package com.sysone.ddogdog.owner.hotel.controller;
+
+import com.sysone.ddogdog.common.config.form.CustomDetails;
+import com.sysone.ddogdog.owner.hotel.model.ResponseHotelDTO;
+import com.sysone.ddogdog.owner.hotel.service.OwnerHotelService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller("ownerHotelViewController")
+@RequiredArgsConstructor
+@RequestMapping("/v1/owners/hotels")
+public class HotelViewController {
+
+    private final OwnerHotelService hotelService;
+
+    @GetMapping("/form")
+    public String getHotelForm() {
+        return "owner/hotelRegister";
+    }
+
+    @GetMapping
+    public String getHotelList(@AuthenticationPrincipal CustomDetails user, Model model) {
+
+        List<ResponseHotelDTO> hotels = hotelService.getHotelsByUserId(user.getUsername());
+        model.addAttribute("hotels", hotels);
+        return "owner/hotelList";
+    }
+
+    @GetMapping("/{id}")
+    public String getHotel(@PathVariable Integer id, Model model) {
+        ResponseHotelDTO hotel = hotelService.getHotel(id);
+        model.addAttribute("hotel", hotel);
+        return "owner/updateHotel";
+    }
+
+}

--- a/src/main/java/com/sysone/ddogdog/owner/reservation/controller/ReservationViewController.java
+++ b/src/main/java/com/sysone/ddogdog/owner/reservation/controller/ReservationViewController.java
@@ -21,9 +21,9 @@ public class ReservationViewController {
     private final OwnerReservationService ownerReservationService;
 
     @GetMapping
-    public String getReservations(@RequestParam("hotelId") Integer hotelId,
-        @RequestParam("year") Integer year,
-        @RequestParam("month") Integer month, Model model) {
+    public String getReservations(@RequestParam Integer hotelId,
+        @RequestParam Integer year,
+        @RequestParam Integer month, Model model) {
         List<ResponseReservationMonthDTO> reservations = ownerReservationService.getReservation(hotelId, year, month);
         model.addAttribute("hotelId", hotelId);
         model.addAttribute("reservations", reservations);
@@ -31,13 +31,18 @@ public class ReservationViewController {
     }
 
     @GetMapping("/day")
-    public String getReservationsDay(@RequestParam("hotelId") Integer hotelId,
-        @RequestParam("year") Integer year,
-        @RequestParam("month") Integer month,
-        @RequestParam(value = "day") Integer day, Model model) {
+    public String getReservationsDay(@RequestParam Integer hotelId,
+        @RequestParam Integer year,
+        @RequestParam Integer month,
+        @RequestParam Integer day, Model model) {
 
         List<ResponseReservationDayDTO> reservations = ownerReservationService.getReservationDay(hotelId, year, month, day);
         model.addAttribute("reservations", reservations);
         return "owner/dayReservation";
+    }
+
+    @GetMapping("/form")
+    public String getForm(){
+        return "owner/calendar";
     }
 }

--- a/src/main/java/com/sysone/ddogdog/owner/reservation/controller/ReservationViewController.java
+++ b/src/main/java/com/sysone/ddogdog/owner/reservation/controller/ReservationViewController.java
@@ -1,0 +1,43 @@
+package com.sysone.ddogdog.owner.reservation.controller;
+
+import com.sysone.ddogdog.owner.reservation.model.ResponseReservationDayDTO;
+import com.sysone.ddogdog.owner.reservation.model.ResponseReservationMonthDTO;
+import com.sysone.ddogdog.owner.reservation.service.OwnerReservationService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Slf4j
+@Controller("OwnerReservationController")
+@RequiredArgsConstructor
+@RequestMapping("/v1/owners/reservations")
+public class ReservationViewController {
+
+    private final OwnerReservationService ownerReservationService;
+
+    @GetMapping
+    public String getReservations(@RequestParam("hotelId") Integer hotelId,
+        @RequestParam("year") Integer year,
+        @RequestParam("month") Integer month, Model model) {
+        List<ResponseReservationMonthDTO> reservations = ownerReservationService.getReservation(hotelId, year, month);
+        model.addAttribute("hotelId", hotelId);
+        model.addAttribute("reservations", reservations);
+        return "owner/monthReservation";
+    }
+
+    @GetMapping("/day")
+    public String getReservationsDay(@RequestParam("hotelId") Integer hotelId,
+        @RequestParam("year") Integer year,
+        @RequestParam("month") Integer month,
+        @RequestParam(value = "day") Integer day, Model model) {
+
+        List<ResponseReservationDayDTO> reservations = ownerReservationService.getReservationDay(hotelId, year, month, day);
+        model.addAttribute("reservations", reservations);
+        return "owner/dayReservation";
+    }
+}

--- a/src/main/java/com/sysone/ddogdog/owner/reservation/mapper/OwnerReservationMapper.java
+++ b/src/main/java/com/sysone/ddogdog/owner/reservation/mapper/OwnerReservationMapper.java
@@ -1,0 +1,17 @@
+package com.sysone.ddogdog.owner.reservation.mapper;
+
+import com.sysone.ddogdog.owner.reservation.model.ReservationDTO;
+import com.sysone.ddogdog.owner.reservation.model.ResponseReservationDayDTO;
+import com.sysone.ddogdog.owner.reservation.model.ResponseReservationMonthDTO;
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface OwnerReservationMapper {
+    List<ResponseReservationMonthDTO> getMonthReservation( @Param("startDate") String startDate, @Param("endDate") String endDate,@Param("hotelId") Integer hotelId);
+
+    List<ResponseReservationDayDTO> getDayReservation(@Param("hotelId") Integer hotelId, @Param("reservationDate") String reservationDate);
+}

--- a/src/main/java/com/sysone/ddogdog/owner/reservation/mapper/OwnerReservationMapper.java
+++ b/src/main/java/com/sysone/ddogdog/owner/reservation/mapper/OwnerReservationMapper.java
@@ -1,10 +1,7 @@
 package com.sysone.ddogdog.owner.reservation.mapper;
 
-import com.sysone.ddogdog.owner.reservation.model.ReservationDTO;
 import com.sysone.ddogdog.owner.reservation.model.ResponseReservationDayDTO;
 import com.sysone.ddogdog.owner.reservation.model.ResponseReservationMonthDTO;
-import java.time.LocalDate;
-import java.util.Date;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;

--- a/src/main/java/com/sysone/ddogdog/owner/reservation/model/ReservationDTO.java
+++ b/src/main/java/com/sysone/ddogdog/owner/reservation/model/ReservationDTO.java
@@ -1,0 +1,20 @@
+package com.sysone.ddogdog.owner.reservation.model;
+
+import com.sysone.ddogdog.owner.room.model.RoomGrade;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ReservationDTO {
+    private Long id;
+    private Long customerId;
+    private String customerName;
+    private String startDate;
+    private String endDate;
+    private String reservationDate;
+    private Integer hotelId;
+    private RoomGrade grade;
+    private Integer price;
+    private Integer roomCount;
+}

--- a/src/main/java/com/sysone/ddogdog/owner/reservation/model/ResponseReservationDayDTO.java
+++ b/src/main/java/com/sysone/ddogdog/owner/reservation/model/ResponseReservationDayDTO.java
@@ -1,0 +1,13 @@
+package com.sysone.ddogdog.owner.reservation.model;
+
+import com.sysone.ddogdog.owner.room.model.RoomGrade;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ResponseReservationDayDTO {
+    private RoomGrade grade;
+    private Integer roomCount;
+    private String customerName;
+}

--- a/src/main/java/com/sysone/ddogdog/owner/reservation/model/ResponseReservationMonthDTO.java
+++ b/src/main/java/com/sysone/ddogdog/owner/reservation/model/ResponseReservationMonthDTO.java
@@ -1,0 +1,17 @@
+package com.sysone.ddogdog.owner.reservation.model;
+
+import com.sysone.ddogdog.owner.room.model.RoomGrade;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ResponseReservationMonthDTO {
+
+    private LocalDate reservationDate;
+    private RoomGrade grade;
+    private Integer roomCount;
+    private Integer price;
+
+}

--- a/src/main/java/com/sysone/ddogdog/owner/reservation/service/OwnerReservationService.java
+++ b/src/main/java/com/sysone/ddogdog/owner/reservation/service/OwnerReservationService.java
@@ -1,0 +1,37 @@
+package com.sysone.ddogdog.owner.reservation.service;
+
+import com.sysone.ddogdog.owner.reservation.mapper.OwnerReservationMapper;
+import com.sysone.ddogdog.owner.reservation.model.ResponseReservationDayDTO;
+import com.sysone.ddogdog.owner.reservation.model.ResponseReservationMonthDTO;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OwnerReservationService {
+
+    private final OwnerReservationMapper ownerReservationMapper;
+
+    public List<ResponseReservationMonthDTO> getReservation(Integer hotelId, Integer year, Integer month) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String startDate = YearMonth.of(year, month).atDay(1).format(formatter);
+        //요청월의 다음달
+        String endDate = YearMonth.of(year, month + 1).atDay(1).format(formatter);
+        return ownerReservationMapper.getMonthReservation(startDate, endDate, hotelId);
+
+    }
+
+    public List<ResponseReservationDayDTO> getReservationDay(Integer hotelId, Integer year, Integer month, Integer day) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDate reservationDate = LocalDate.of(year, month, day);
+        String reservationDateStr = reservationDate.format(formatter);
+        return ownerReservationMapper.getDayReservation(hotelId, reservationDateStr);
+    }
+
+}

--- a/src/main/java/com/sysone/ddogdog/owner/room/controller/RoomController.java
+++ b/src/main/java/com/sysone/ddogdog/owner/room/controller/RoomController.java
@@ -5,6 +5,7 @@ import com.sysone.ddogdog.owner.room.model.RoomDTO;
 import com.sysone.ddogdog.owner.room.model.RoomGrade;
 import com.sysone.ddogdog.owner.room.model.ResponseRoomDTO;
 import com.sysone.ddogdog.owner.room.service.RoomService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -26,7 +27,9 @@ public class RoomController {
 
     @GetMapping("/form/{hotelId}")
     public String getRoomRegisterForm(@PathVariable Integer hotelId, Model model) {
+        List<RoomGrade> grades = roomService.getHotelExistGrade(hotelId);
         model.addAttribute("hotelId", hotelId);
+        model.addAttribute("grades",grades);
         return "owner/roomRegister";
     }
 

--- a/src/main/java/com/sysone/ddogdog/owner/room/controller/RoomController.java
+++ b/src/main/java/com/sysone/ddogdog/owner/room/controller/RoomController.java
@@ -3,6 +3,7 @@ package com.sysone.ddogdog.owner.room.controller;
 import com.sysone.ddogdog.owner.room.model.RequestRoomDTO;
 import com.sysone.ddogdog.owner.room.service.RoomService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,7 +22,7 @@ public class RoomController {
     @PostMapping
     public ResponseEntity<Void> saveRoom(@ModelAttribute RequestRoomDTO requestRoomDTO) {
         roomService.saveRoom(requestRoomDTO);
-        return ResponseEntity.created(null).build();
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
 

--- a/src/main/java/com/sysone/ddogdog/owner/room/controller/RoomController.java
+++ b/src/main/java/com/sysone/ddogdog/owner/room/controller/RoomController.java
@@ -1,37 +1,22 @@
 package com.sysone.ddogdog.owner.room.controller;
 
 import com.sysone.ddogdog.owner.room.model.RequestRoomDTO;
-import com.sysone.ddogdog.owner.room.model.RoomDTO;
-import com.sysone.ddogdog.owner.room.model.RoomGrade;
-import com.sysone.ddogdog.owner.room.model.ResponseRoomDTO;
 import com.sysone.ddogdog.owner.room.service.RoomService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller("ownerRoomController")
+@RestController("ownerRoomController")
 @RequiredArgsConstructor
 @RequestMapping("/v1/owners/rooms")
 public class RoomController {
 
     private final RoomService roomService;
 
-    @GetMapping("/form/{hotelId}")
-    public String getRoomRegisterForm(@PathVariable Integer hotelId, Model model) {
-        List<RoomGrade> grades = roomService.getHotelExistGrade(hotelId);
-        model.addAttribute("hotelId", hotelId);
-        model.addAttribute("grades",grades);
-        return "owner/roomRegister";
-    }
 
     @PostMapping
     public ResponseEntity<Void> saveRoom(@ModelAttribute RequestRoomDTO requestRoomDTO) {
@@ -39,22 +24,6 @@ public class RoomController {
         return ResponseEntity.created(null).build();
     }
 
-    @GetMapping
-    public String getRoomList(@RequestParam("hotelId") Integer hotelId, Model model) {
-        ResponseRoomDTO rooms = roomService.getRoomList(hotelId);
-        model.addAttribute("hotelId", rooms.getHotelId());
-        model.addAttribute("hotelName", rooms.getBusiness_name());
-        model.addAttribute("rooms", rooms.getResponseRoomDTOList());
-        return "owner/roomList";
-    }
-
-    @GetMapping("/updateform/{grade}")
-    public String getUpdateRoomForm(@PathVariable RoomGrade grade, @RequestParam("hotelId") Integer hotelId, Model model) {
-        RoomDTO room = roomService.getRoom(grade, hotelId);
-        model.addAttribute("room", room);
-        model.addAttribute("hotelId", hotelId);
-        return "owner/updateRoom";
-    }
 
     @PutMapping
     public ResponseEntity<Void> getUpdateRoom(@ModelAttribute RequestRoomDTO requestRoomDTO) {

--- a/src/main/java/com/sysone/ddogdog/owner/room/controller/RoomViewController.java
+++ b/src/main/java/com/sysone/ddogdog/owner/room/controller/RoomViewController.java
@@ -1,0 +1,48 @@
+package com.sysone.ddogdog.owner.room.controller;
+
+import com.sysone.ddogdog.owner.room.model.ResponseRoomDTO;
+import com.sysone.ddogdog.owner.room.model.RoomDTO;
+import com.sysone.ddogdog.owner.room.model.RoomGrade;
+import com.sysone.ddogdog.owner.room.service.RoomService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller("ownerRoomViewController")
+@RequiredArgsConstructor
+@RequestMapping("/v1/owners/rooms")
+public class RoomViewController {
+
+    private final RoomService roomService;
+
+    @GetMapping("/form/{hotelId}")
+    public String getRoomRegisterForm(@PathVariable Integer hotelId, Model model) {
+        List<RoomGrade> grades = roomService.getHotelExistGrade(hotelId);
+        model.addAttribute("hotelId", hotelId);
+        model.addAttribute("grades", grades);
+        return "owner/roomRegister";
+    }
+
+    @GetMapping
+    public String getRoomList(@RequestParam("hotelId") Integer hotelId, Model model) {
+        ResponseRoomDTO rooms = roomService.getRoomList(hotelId);
+        model.addAttribute("hotelId", rooms.getHotelId());
+        model.addAttribute("hotelName", rooms.getBusiness_name());
+        model.addAttribute("rooms", rooms.getResponseRoomDTOList());
+        return "owner/roomList";
+    }
+
+    @GetMapping("/updateform/{grade}")
+    public String getUpdateRoomForm(@PathVariable RoomGrade grade, @RequestParam("hotelId") Integer hotelId, Model model) {
+        RoomDTO room = roomService.getRoom(grade, hotelId);
+        model.addAttribute("room", room);
+        model.addAttribute("hotelId", hotelId);
+        return "owner/updateRoom";
+    }
+
+}

--- a/src/main/java/com/sysone/ddogdog/owner/room/mapper/OwnerRoomMapper.java
+++ b/src/main/java/com/sysone/ddogdog/owner/room/mapper/OwnerRoomMapper.java
@@ -17,4 +17,6 @@ public interface OwnerRoomMapper {
     void updateRoom(RoomDTO roomDTO);
 
     void updateRoomWithoutImg(RoomDTO roomDTO);
+
+    List<RoomGrade> getHotelExistGrade(Integer hotelId);
 }

--- a/src/main/java/com/sysone/ddogdog/owner/room/model/RoomGrade.java
+++ b/src/main/java/com/sysone/ddogdog/owner/room/model/RoomGrade.java
@@ -6,12 +6,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum RoomGrade {
-    DELUXE("디럭스 | 3평 미만"),
-    SUPERIOR("슈페리어 | 3평이상 5평미만"),
-    SUITE("스위트 | 5평이상 7평미만"),
-    ROYAL_SUITE("로얄스위트 | 7평이상")
-    ;
+    DELUXE("디럭스   | 3평 미만"),
+    SUPERIOR("슈페리어  | 3평이상 5평미만"),
+    SUITE("스위트   | 5평이상 7평미만"),
+    ROYAL_SUITE("로얄스위트 | 7평이상");
 
-    private String detail;
+    private final String detail;
 
 }

--- a/src/main/java/com/sysone/ddogdog/owner/room/model/RoomGrade.java
+++ b/src/main/java/com/sysone/ddogdog/owner/room/model/RoomGrade.java
@@ -1,8 +1,17 @@
 package com.sysone.ddogdog.owner.room.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum RoomGrade {
-    DELUXE,
-    SUPERIOR,
-    SUITE,
-    ROYAL_SUITE
+    DELUXE("디럭스 | 3평 미만"),
+    SUPERIOR("슈페리어 | 3평이상 5평미만"),
+    SUITE("스위트 | 5평이상 7평미만"),
+    ROYAL_SUITE("로얄스위트 | 7평이상")
+    ;
+
+    private String detail;
+
 }

--- a/src/main/java/com/sysone/ddogdog/owner/room/service/RoomService.java
+++ b/src/main/java/com/sysone/ddogdog/owner/room/service/RoomService.java
@@ -8,6 +8,7 @@ import com.sysone.ddogdog.owner.room.model.RoomDTO;
 import com.sysone.ddogdog.owner.room.model.RoomGrade;
 import com.sysone.ddogdog.owner.room.model.ResponseRoomDTO;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -54,5 +55,17 @@ public class RoomService {
             RoomDTO roomDTO = RoomDTO.updateRoomWithoutImg(requestRoomDTO);
             ownerRoomMapper.updateRoomWithoutImg(roomDTO);
         }
+    }
+
+    public List<RoomGrade> getHotelExistGrade(Integer hotelId){
+        //전체 등급 리스트
+        List<RoomGrade> allGrade = List.of(RoomGrade.values());
+        //호텔 보유 등급 리스트
+        List<RoomGrade> existGrades = ownerRoomMapper.getHotelExistGrade(hotelId);
+
+        // 호텔 등록된 객실 존재 시 해당 등급 제외 후 반환, 없을 시 전체 반환
+        return allGrade.stream()
+            .filter(grade -> !existGrades.contains(grade))
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/resources/mapper/owner/reservation.xml
+++ b/src/main/resources/mapper/owner/reservation.xml
@@ -29,7 +29,7 @@
       AND r.canceled = 0
       AND r.start_date &lt; TO_DATE(#{endDate}, 'YYYY-MM-DD')
       AND r.end_date &gt; TO_DATE(#{startDate}, 'YYYY-MM-DD')
-    WHERE d.reservation_date >= r.start_date
+    WHERE d.reservation_date &gt;= r.start_date
       AND d.reservation_date &lt; r.end_date
       ) nr
         LEFT JOIN choose_rooms cr ON nr.id = cr.reservation_id

--- a/src/main/resources/mapper/owner/reservation.xml
+++ b/src/main/resources/mapper/owner/reservation.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.sysone.ddogdog.owner.reservation.mapper.OwnerReservationMapper">
+  <resultMap type="com.sysone.ddogdog.owner.reservation.model.ResponseReservationMonthDTO" id="monthReservation">
+    <result property="reservationDate" column="reservation_date"/>
+    <result property="grade" column="grade"/>
+    <result property="roomCount" column="room_count"/>
+    <result property="price" column="price"/>
+  </resultMap>
+
+  <resultMap type="com.sysone.ddogdog.owner.reservation.model.ResponseReservationDayDTO" id="dayReservation">
+    <result property="grade" column="grade"/>
+    <result property="roomCount" column="room_count"/>
+    <result property="customerName" column="name"/>
+  </resultMap>
+
+  <select id="getMonthReservation" parameterType="com.sysone.ddogdog.owner.reservation.model.ReservationDTO" resultMap="monthReservation">
+    SELECT nr.reservation_date AS reservation_date, rs.grade AS grade, COUNT(*) AS room_count, SUM(cr.now_price) AS price
+    FROM (
+           WITH date_range AS (
+             SELECT TO_DATE(#{startDate}, 'YYYY-MM-DD') + LEVEL - 1 AS reservation_date
+             FROM DUAL
+           CONNECT BY LEVEL &lt;= (TO_DATE(#{endDate}, 'YYYY-MM-DD') - TO_DATE(#{startDate}, 'YYYY-MM-DD') + 1)
+         )
+    SELECT d.reservation_date, r.id, r.count
+    FROM date_range d
+           JOIN RESERVATIONS r ON r.hotel_id = #{hotelId}
+      AND r.canceled = 0
+      AND r.start_date &lt; TO_DATE(#{endDate}, 'YYYY-MM-DD')
+      AND r.end_date &gt; TO_DATE(#{startDate}, 'YYYY-MM-DD')
+    WHERE d.reservation_date >= r.start_date
+      AND d.reservation_date &lt; r.end_date
+      ) nr
+        LEFT JOIN choose_rooms cr ON nr.id = cr.reservation_id
+      LEFT JOIN (SELECT id, grade FROM ROOMS WHERE hotel_id = #{hotelId}) rs ON cr.room_id = rs.id
+    GROUP BY nr.reservation_date, rs.grade
+    ORDER BY reservation_date, grade
+  </select>
+
+  <select id="getDayReservation" parameterType="com.sysone.ddogdog.owner.reservation.model.ReservationDTO" resultMap="dayReservation">
+    SELECT rm.grade, count(*) as room_count, c.name
+    FROM (SELECT id, customer_id, count, price
+          FROM reservations
+          WHERE hotel_id = #{hotelId}
+            AND start_date &lt;= TO_DATE(#{reservationDate}, 'YYYY-MM-DD')
+            AND end_date &gt; TO_DATE(#{reservationDate}, 'YYYY-MM-DD')
+            AND canceled = 0) r
+           JOIN customers c
+                ON r.customer_id = c.id
+           JOIN choose_rooms cr ON r.id = cr.reservation_id
+           JOIN rooms rm ON rm.id = cr.room_id
+    group by rm.grade, r.count, c.name
+  </select>
+
+</mapper>

--- a/src/main/resources/mapper/owner/room.xml
+++ b/src/main/resources/mapper/owner/room.xml
@@ -68,4 +68,10 @@
       )}
   </update>
 
+  <select id="getHotelExistGrade" parameterType="Integer" resultType="com.sysone.ddogdog.owner.room.model.RoomGrade">
+    SELECT DISTINCT grade
+    FROM ROOMS
+    WHERE hotel_id = ${hotelId}
+  </select>
+
 </mapper>

--- a/src/main/webapp/WEB-INF/views/owner/dayReservation.jsp
+++ b/src/main/webapp/WEB-INF/views/owner/dayReservation.jsp
@@ -1,0 +1,34 @@
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>OWNER: 일 예약 현황</title>
+</head>
+<body>
+<div class="header-box">
+    <jsp:include page="component/header.jsp"></jsp:include>
+</div>
+<!-- 테스트용 입니다. -->
+<div class="container">
+    <h1>호텔 일별 예약 현황 확인</h1>
+    <div class="calendar">
+        <c:forEach var="reservation" items="${reservations}">
+            <div class="reservation-card">
+                <p>${reservation.grade}</p>
+                <p>${reservation.roomCount}</p>
+                <p>${reservation.customerName}</p>
+            </div>
+        </c:forEach>
+    </div>
+</div>
+
+<div class="footer-box">
+    <jsp:include page="component/footer.jsp"></jsp:include>
+</div>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/owner/monthReservation.jsp
+++ b/src/main/webapp/WEB-INF/views/owner/monthReservation.jsp
@@ -1,0 +1,35 @@
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>OWNER:월 예약 현황</title>
+</head>
+<body>
+<div class="header-box">
+    <jsp:include page="component/header.jsp"></jsp:include>
+</div>
+<!-- 테스트용 입니다. -->
+<div class="container">
+    <h1>호텔 예약 현황 확인</h1>
+    <div class="calendar">
+        <c:forEach var="reservation" items="${reservations}">
+            <div class="reservation-card">
+                <p>${reservation.reservationDate}</p>
+                <p>${reservation.grade}</p>
+                <p>${reservation.roomCount}</p>
+                <p>${reservation.price}</p>
+            </div>
+        </c:forEach>
+    </div>
+</div>
+
+<div class="footer-box">
+    <jsp:include page="component/footer.jsp"></jsp:include>
+</div>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/owner/roomRegister.jsp
+++ b/src/main/webapp/WEB-INF/views/owner/roomRegister.jsp
@@ -30,10 +30,9 @@
         <div class="form-group">
             <label for="room-grade">객실 등급</label>
             <select id="room-grade" class="form-control">
-                <option value="DELUXE">디럭스 | 3평 미만</option>
-                <option value="SUPERIOR">슈페리어 | 3평이상 5평미만</option>
-                <option value="SUITE">스위트 | 5평이상 7평미만</option>
-                <option value="ROYAL_SUITE">로얄스위트 | 7평이상</option>
+                <c:forEach var="grade" items="${grades}">
+                    <option value="${grade.name()}">${grade.detail}</option>
+                </c:forEach>
             </select>
         </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* Owner 객실 등록 시 이미 생성된 룸 등급은 재 생성하지 못하도록 서비스 로직 수정하였습니다.
* 전체 뷰컨트롤러 분리
* 월별 일별 예약 조회 API 생성

### 스크린샷 (선택)
* 등록된 객실이 없는 상태
<img width="548" alt="객실미등록상태" src="https://github.com/user-attachments/assets/adcca49f-6ee4-4509-8235-b38f77e24ce7">

* 등록된 객실이 있을 때(슈페리어 등급 기등록 상태)
<img width="728" alt="등록된 객실이 있는 상태" src="https://github.com/user-attachments/assets/c07cce9c-dde2-4530-8264-4db59f26f355">

## 💬리뷰 요구사항(선택)
